### PR TITLE
New version: v1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,34 @@ This is NOT a plugin that adds user registration or any of that other stuff you'
 
 **You will need a server to function as a login server. Any minecraft server will do, but I recommend [NanoLimbo](https://github.com/Nan1t/NanoLimbo), as it is extremely lightweight, and will only exist to facilitate login requests**
 
-The plugin uses a YAML configuration file (`config.yml`) to manage its settings. Below are some of the configurable options, comments are included in the file:
+**It is recommended to set the permission node `velocity.command.server` to false in your permission plugins default everyone group, otherwise players will be able to bypass the plugin!**
 
+
+The plugin uses a TOML configuration file (`config.toml`) to manage its settings. Below are some of the configurable options, comments are included in the file:
+#### core
 - `loginServer`: The server where players are redirected for login.
 - `hubServer`: The main server.
 - `serverPassword`: The password required for login.
 - `oneTimeLogin`: Boolean to enable/disable one-time login. Default is `true`.
+#### core.bypass
 - `bypassNode`: The permission node for bypassing login.
 - `pluginGrantsBypass`: Boolean to enable/disable plugin-granted bypass. Default is `true`.
+- `disableLoginCommandOnBypass`: Boolean to disable login command if bypass is granted. Default is `true`.
+#### core.bypass.methods
 - `bypassMethod`: Method to grant bypass permissions. Options are `user` or `group`.
 - `bypassGroup`: The group to add the player to if `bypassMethod` is `group`.
-- `disableLoginCommandOnBypass`: Boolean to disable login command if bypass is granted. Default is `true`.
+#### core.kick
 - `kickMessage`: Message displayed when a player is kicked.
-- `kickTimeout`: Timeout duration before a player is kicked.
+- `kickTimeout`: Timeout duration before a player is kicked, in seconds.
+#### messages
 - `noPassword`: Message displayed when no password is provided.
 - `wrongPassword`: Message displayed when the wrong password is provided.
+- `welcomeMessage`: Message to be displayed when someone joins the login server.
+#### misc
 - `loginCommandGrantedToEveryone`: Boolean to grant the login command to everyone. Default is `true`.
 - `loginCommandNode`: The permission node for the login command. Default is `loginpassword.login`.
+- `pluginEnabled`: Boolean to enable/disable the plugin. Default is `true`.
+- `configVersion`: Version of the plugin this config file was last migrated to. Do not touch.
 
 ## Installation
 
@@ -50,13 +61,16 @@ The plugin uses a YAML configuration file (`config.yml`) to manage its settings.
 1. Download the plugin JAR file.
 2. Place the JAR file in the `plugins` directory of your Velocity server.
 3. Start the server to generate the default configuration file.
-4. Edit the `config.yml` file in the `plugins/LoginPassword` directory to suit your needs.
+4. Edit the `config.toml` file in the `plugins/LoginPassword` directory to suit your needs.
 5. Configure `velocity.toml` by adding the login server to `[servers]` table. If you want `ping-passthrough = "all"` to work correctly, have only the hub server in the `try = []` array, do not add the login server to the array. The plugin will handle redirecting players to the login server.
-6. Restart the server or run `velocity reload` to reload all plugins.
+6. Restart the server or run `velocity reload` to reload all plugins and apply the new `velocity.toml`.
+7. For future changes to `config.toml`, apply the changes using `loginpassword reload`
 
 ## Usage
 
 Once installed and configured, the plugin will prompt players to enter a password upon connecting to the server. Depending on the configuration, players may only need to authenticate once. Administrators can manage permissions using LuckPerms or another permissions plugin to grant or revoke bypass permissions.
+
+I encourage you to look at NanoLimbo's `settings.yml` as well, to see if there are any changes you want to make to the default join messages that appear.
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'net.trim02'
-version = '1.3'
+version = '1.4-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -30,6 +30,8 @@ dependencies {
     compileOnly("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT", "net.luckperms:api:5.4")
     annotationProcessor("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
     implementation("com.technicjelle:UpdateChecker:2.5.1")
+    implementation("com.electronwill.night-config:core:3.6.0")
+
 }
 
 def targetJavaVersion = 17
@@ -42,6 +44,9 @@ tasks.named('shadowJar', ShadowJar) {
     include('/com/technicjelle/**')
     include('*')
     include('/net/trim02/**')
+
+    include('/com/electronwill/**')
+
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     id 'java'
     id 'eclipse'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.8'
+    id("com.gradleup.shadow") version "9.0.0-beta12"
 }
 
 group = 'net.trim02'
@@ -17,16 +20,28 @@ repositories {
         name = "sonatype"
         url = "https://oss.sonatype.org/content/groups/public/"
     }
+    maven {
+        name = "bluecoloredReleases"
+        url = uri("https://repo.bluecolored.de/releases")
+    }
 }
 
 dependencies {
     compileOnly("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT", "net.luckperms:api:5.4")
     annotationProcessor("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
+    implementation("com.technicjelle:UpdateChecker:2.5.1")
 }
 
 def targetJavaVersion = 17
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
+}
+
+tasks.named('shadowJar', ShadowJar) {
+    archiveClassifier.set('')
+    include('/com/technicjelle/**')
+    include('*')
+    include('/net/trim02/**')
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'net.trim02'
-version = '1.4-SNAPSHOT'
+version = '1.4'
 
 repositories {
     mavenCentral()

--- a/src/main/java/net/trim02/loginPassword/AdminCommand.java
+++ b/src/main/java/net/trim02/loginPassword/AdminCommand.java
@@ -1,0 +1,111 @@
+package net.trim02.loginPassword;
+
+import net.trim02.loginPassword.Config.configVar;
+
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.proxy.ConsoleCommandSource;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.slf4j.Logger;
+
+
+public class AdminCommand implements SimpleCommand {
+    protected final ProxyServer server;
+    protected final Logger logger;
+    protected final Config config;
+
+    public AdminCommand(ProxyServer server, Logger logger, Config config) {
+        this.server = server;
+        this.logger = logger;
+        this.config = config;
+    }
+
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+
+        if (args.length == 0) {
+            // Future Reference:
+            // /loginpassword set <key> <value> - Sets the config value
+            // /loginpassword get <key> - Gets the config value
+            source.sendMessage(Component.text(
+                    """
+                            loginPassword v%s by trim02
+                            /loginpassword reload - Reloads the config
+                            /loginpassword config - Shows the current config
+                            /loginpassword toggle - Enables/disables the plugin
+                            """.formatted(BuildConstants.VERSION), NamedTextColor.GREEN));
+            return;
+        }
+        switch (args[0]) {
+            case "reload" -> {
+                config.reloadConfig();
+                source.sendMessage(Component.text("Config reloaded", NamedTextColor.GREEN));
+            }
+            case "config" -> source.sendMessage(Component.text(
+                    """
+                            loginPassword v%s by trim02
+                            Config:
+                            pluginEnabled: %s
+                            [core]
+                            loginServer: %s
+                            hubServer: %s
+                            serverPassword: %s
+                            oneTimeLogin: %s
+                            [core.bypass]
+                            bypassNode: %s
+                            disableLoginCommandOnBypass: %s
+                            pluginGrantsBypass: %s
+                            [core.bypass.methods]
+                            bypassGroup: %s
+                            bypassMethod: %s
+                            [core.kick]
+                            kickTimeout: %s
+                            kickMessage: %s
+                            [messages]
+                            wrongPassword: %s
+                            noPassword: %s
+                            """.formatted(BuildConstants.VERSION,
+                            configVar.pluginEnabled, configVar.loginServer,
+                            configVar.hubServer, configVar.serverPassword, configVar.oneTimeLogin,
+                            configVar.bypassNode, configVar.disableLoginCommandOnBypass, configVar.pluginGrantsBypass,
+                            configVar.bypassGroup, configVar.bypassMethod, configVar.kickTimeout,
+                            configVar.kickMessage, configVar.wrongPassword, configVar.noPassword), NamedTextColor.GREEN));
+
+//        else if (args[0].equals("set")) {
+//            if (args.length < 3) {
+//                source.sendMessage(Component.text("Usage: /loginpassword set <key> <value>", NamedTextColor.RED));
+//                return;
+//            }
+//            config.setConfigValue(args[1], args[2]);
+//            source.sendMessage(Component.text("Config set", NamedTextColor.GREEN));
+//        }
+//        else if (args[0].equals("get")) {
+//            if (args.length < 2) {
+//                source.sendMessage(Component.text("Usage: /loginpassword get <key>", NamedTextColor.RED));
+//                return;
+//            }
+//            String value = configVar.getConfig(args[1]);
+//            source.sendMessage(Component.text(value, NamedTextColor.GREEN));
+//        }
+            case "toggle" -> {
+                config.togglePlugin();
+                source.sendMessage(Component.text("Plugin has been " + (configVar.pluginEnabled ? "enabled" : "disabled"),
+                        NamedTextColor.GREEN));
+//                source.sendMessage(Component.text("Plugin toggled", NamedTextColor.GREEN));
+            }
+            default -> source.sendMessage(Component.text("Unknown command", NamedTextColor.RED));
+        }
+    }
+
+    @Override
+    public boolean hasPermission(Invocation invocation) {
+        CommandSource source = invocation.source();
+        return (source instanceof Player player && player.hasPermission("loginpassword.admin")) || (source instanceof ConsoleCommandSource);
+    }
+}

--- a/src/main/java/net/trim02/loginPassword/AdminCommands.java
+++ b/src/main/java/net/trim02/loginPassword/AdminCommands.java
@@ -1,0 +1,4 @@
+package net.trim02.loginPassword;
+
+public class AdminCommands {
+}

--- a/src/main/java/net/trim02/loginPassword/AdminCommands.java
+++ b/src/main/java/net/trim02/loginPassword/AdminCommands.java
@@ -1,4 +1,0 @@
-package net.trim02.loginPassword;
-
-public class AdminCommands {
-}

--- a/src/main/java/net/trim02/loginPassword/Config.java
+++ b/src/main/java/net/trim02/loginPassword/Config.java
@@ -42,6 +42,7 @@ public class Config {
         public static Integer kickTimeout;
         public static String noPassword;
         public static String wrongPassword;
+        public static String welcomeMessage;
         public static Boolean loginCommandNegated;
         public static String loginCommandNode;
         public static String configVersion;
@@ -79,6 +80,7 @@ public class Config {
         if(!configVar.configVersion.equals(BuildConstants.VERSION)){
             // logger.warn("Config file version is different from plugin version. Migrating config file to new version.");
             migrateConfigVersion();
+            initConfig();
         }
         // Check if old yaml config file exists
         if (Files.exists(dataDirectory.resolve("config.yml"))) {
@@ -121,6 +123,7 @@ public class Config {
         configVar.kickTimeout = config.get("core.kick.kickTimeout");
         configVar.noPassword = config.get("messages.noPassword");
         configVar.wrongPassword = config.get("messages.wrongPassword");
+        configVar.welcomeMessage = config.get("messages.welcomeMessage");
         configVar.loginCommandNegated = config.get("misc.loginCommandGrantedToEveryone");
         configVar.loginCommandNode = config.get("misc.loginCommandNode");
         configVar.configVersion = config.get("misc.configVersion");
@@ -196,6 +199,7 @@ public class Config {
         templateConfig.set("core.kick.kickTimeout", config.get("core.kick.kickTimeout"));
         templateConfig.set("messages.noPassword", config.get("messages.noPassword"));
         templateConfig.set("messages.wrongPassword", config.get("messages.wrongPassword"));
+        templateConfig.set("messages.welcomeMessage", config.get("messages.welcomeMessage"));
         templateConfig.set("misc.loginCommandGrantedToEveryone", config.get("misc.loginCommandGrantedToEveryone"));
         templateConfig.set("misc.loginCommandNode", config.get("misc.loginCommandNode"));
         templateConfig.set("misc.pluginEnabled", config.get("misc.pluginEnabled"));

--- a/src/main/java/net/trim02/loginPassword/Config.java
+++ b/src/main/java/net/trim02/loginPassword/Config.java
@@ -1,0 +1,310 @@
+package net.trim02.loginPassword;
+
+import com.electronwill.nightconfig.core.file.FileConfig;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import com.velocitypowered.api.proxy.ProxyServer;
+import org.slf4j.Logger;
+import org.spongepowered.configurate.CommentedConfigurationNode;
+import org.spongepowered.configurate.ConfigurateException;
+import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class Config {
+    protected final ProxyServer server;
+    protected final loginPassword plugin;
+    protected final Logger logger;
+    protected final Path dataDirectory;
+
+    public Config(loginPassword plugin, ProxyServer server, Logger logger, Path dataDirectory) {
+        this.server = server;
+        this.plugin = plugin;
+        this.logger = logger;
+        this.dataDirectory = dataDirectory;
+
+
+    }
+
+    static class configVar {
+        public static String loginServer;
+        public static String hubServer;
+        public static String serverPassword;
+        public static Boolean oneTimeLogin;
+        public static String bypassNode;
+        public static Boolean pluginGrantsBypass;
+        public static String bypassMethod;
+        public static String bypassGroup;
+        public static Boolean disableLoginCommandOnBypass;
+        public static String kickMessage;
+        public static Integer kickTimeout;
+        public static String noPassword;
+        public static String wrongPassword;
+        public static Boolean loginCommandNegated;
+        public static String loginCommandNode;
+        public static String configVersion;
+        public static Boolean pluginEnabled;
+    }
+
+    public void initConfig() throws IOException {
+        if (Files.notExists(dataDirectory)) {
+            try {
+                Files.createDirectory(dataDirectory);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        final Path configFile = dataDirectory.resolve("config.toml");
+        if (Files.notExists(configFile)) {
+            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.toml")) {
+                Files.copy(stream, configFile);
+
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        // Check if the config file is empty
+        if (Files.size(configFile) == 0) {
+            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.toml")) {
+                Files.copy(stream, configFile);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        getTomlConfig(configFile);
+        // Check if local config file version value is different from plugin version
+        if(!configVar.configVersion.equals(BuildConstants.VERSION)){
+            // logger.warn("Config file version is different from plugin version. Migrating config file to new version.");
+            migrateConfigVersion();
+        }
+        // Check if old yaml config file exists
+        if (Files.exists(dataDirectory.resolve("config.yml"))) {
+            logger.warn("Old config file found. Migrating to new config file format.");
+            migrateYamlToToml();
+            initConfig();
+        }
+    }
+
+
+    public void getTomlConfig(Path configFile) {
+        if (Files.notExists(dataDirectory)) {
+            try {
+                Files.createDirectory(dataDirectory);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        // final Path configFile = dataDirectory.resolve("config.toml");
+        if (Files.notExists(configFile)) {
+            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.toml")) {
+                Files.copy(stream, configFile);
+
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        FileConfig config = FileConfig.of(configFile);
+        config.load();
+        configVar.loginServer = config.get("core.loginServer");
+        configVar.hubServer = config.get("core.hubServer");
+        configVar.serverPassword = config.get("core.serverPassword");
+        configVar.oneTimeLogin = config.get("core.oneTimeLogin");
+        configVar.pluginGrantsBypass = config.get("core.bypass.pluginGrantsBypass");
+        configVar.disableLoginCommandOnBypass = config.get("core.bypass.disableLoginCommandOnBypass");
+        configVar.bypassNode = config.get("core.bypass.bypassNode");
+        configVar.bypassMethod = config.get("core.bypass.methods.bypassMethod");
+        configVar.bypassGroup = config.get("core.bypass.methods.bypassGroup");
+        configVar.kickMessage = config.get("core.kick.kickMessage");
+        configVar.kickTimeout = config.get("core.kick.kickTimeout");
+        configVar.noPassword = config.get("messages.noPassword");
+        configVar.wrongPassword = config.get("messages.wrongPassword");
+        configVar.loginCommandNegated = config.get("misc.loginCommandGrantedToEveryone");
+        configVar.loginCommandNode = config.get("misc.loginCommandNode");
+        configVar.configVersion = config.get("misc.configVersion");
+        configVar.pluginEnabled = config.get("misc.pluginEnabled");
+        config.close();
+
+    }
+    public void migrateConfigVersion() {
+        Path templateConfigFile = null;
+        try {
+            templateConfigFile = Files.createTempFile(dataDirectory, "configTemp", ".toml");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        InputStream templateStream = this.getClass().getClassLoader().getResourceAsStream("config.toml");
+        try {
+            Files.copy(templateStream, templateConfigFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        Path configFile = dataDirectory.resolve("config.toml");
+
+        FileConfig templateConfig = FileConfig.of(templateConfigFile);
+        FileConfig config = FileConfig.of(configFile);
+        templateConfig.load();
+        //    System.err.println("Template Config values:");
+        //    System.err.println("core.loginServer: " + templateConfig.get("core.loginServer"));
+        //    System.err.println("core.hubServer: " + templateConfig.get("core.hubServer"));
+        //    System.err.println("core.serverPassword: " + templateConfig.get("core.serverPassword"));
+        //    System.err.println("core.oneTimeLogin: " + templateConfig.get("core.oneTimeLogin"));
+        //    System.err.println("core.bypass.pluginGrantsBypass: " + templateConfig.get("core.bypass.pluginGrantsBypass"));
+        //    System.err.println("core.bypass.disableLoginCommandOnBypass: " + templateConfig.get("core.bypass.disableLoginCommandOnBypass"));
+        //    System.err.println("core.bypass.bypassNode: " + templateConfig.get("core.bypass.bypassNode"));
+        //    System.err.println("core.bypass.methods.bypassMethod: " + templateConfig.get("core.bypass.methods.bypassMethod"));
+        //    System.err.println("core.bypass.methods.bypassGroup: " + templateConfig.get("core.bypass.methods.bypassGroup"));
+        //    System.err.println("core.kick.kickMessage: " + templateConfig.get("core.kick.kickMessage"));
+        //    System.err.println("core.kick.kickTimeout: " + templateConfig.get("core.kick.kickTimeout"));
+        //    System.err.println("messages.noPassword: " + templateConfig.get("messages.noPassword"));
+        //    System.err.println("messages.wrongPassword: " + templateConfig.get("messages.wrongPassword"));
+        //    System.err.println("misc.loginCommandGrantedToEveryone: " + templateConfig.get("misc.loginCommandGrantedToEveryone"));
+        //    System.err.println("misc.loginCommandNode: " + templateConfig.get("misc.loginCommandNode"));
+        //    System.err.println("misc.configVersion: " + templateConfig.get("misc.configVersion"));
+        //    System.err.println("Build Version: " + BuildConstants.VERSION);
+        config.load();
+        //    System.err.println("Local Config values:");
+        //    System.err.println("core.loginServer: " + config.get("core.loginServer"));
+        //    System.err.println("core.hubServer: " + config.get("core.hubServer"));
+        //    System.err.println("core.serverPassword: " + config.get("core.serverPassword"));
+        //    System.err.println("core.oneTimeLogin: " + config.get("core.oneTimeLogin"));
+        //    System.err.println("core.bypass.pluginGrantsBypass: " + config.get("core.bypass.pluginGrantsBypass"));
+        //    System.err.println("core.bypass.disableLoginCommandOnBypass: " + config.get("core.bypass.disableLoginCommandOnBypass"));
+        //    System.err.println("core.bypass.bypassNode: " + config.get("core.bypass.bypassNode"));
+        //    System.err.println("core.bypass.methods.bypassMethod: " + config.get("core.bypass.methods.bypassMethod"));
+        //    System.err.println("core.bypass.methods.bypassGroup: " + config.get("core.bypass.methods.bypassGroup"));
+        //    System.err.println("core.kick.kickMessage: " + config.get("core.kick.kickMessage"));
+        //    System.err.println("core.kick.kickTimeout: " + config.get("core.kick.kickTimeout"));
+        //    System.err.println("messages.noPassword: " + config.get("messages.noPassword"));
+        //    System.err.println("messages.wrongPassword: " + config.get("messages.wrongPassword"));
+        //    System.err.println("misc.loginCommandGrantedToEveryone: " + config.get("misc.loginCommandGrantedToEveryone"));
+        //    System.err.println("misc.loginCommandNode: " + config.get("misc.loginCommandNode"));
+        //    System.err.println("misc.configVersion: " + config.get("misc.configVersion"));
+        //    System.err.println("Build Version: " + BuildConstants.VERSION);
+        templateConfig.set("core.loginServer", config.get("core.loginServer"));
+        templateConfig.set("core.hubServer", config.get("core.hubServer"));
+        templateConfig.set("core.serverPassword", config.get("core.serverPassword"));
+        templateConfig.set("core.oneTimeLogin", config.get("core.oneTimeLogin"));
+        templateConfig.set("core.bypass.pluginGrantsBypass", config.get("core.bypass.pluginGrantsBypass"));
+        templateConfig.set("core.bypass.disableLoginCommandOnBypass", config.get("core.bypass.disableLoginCommandOnBypass"));
+        templateConfig.set("core.bypass.bypassNode", config.get("core.bypass.bypassNode"));
+        templateConfig.set("core.bypass.methods.bypassMethod", config.get("core.bypass.methods.bypassMethod"));
+        templateConfig.set("core.bypass.methods.bypassGroup", config.get("core.bypass.methods.bypassGroup"));
+        templateConfig.set("core.kick.kickMessage", config.get("core.kick.kickMessage"));
+        templateConfig.set("core.kick.kickTimeout", config.get("core.kick.kickTimeout"));
+        templateConfig.set("messages.noPassword", config.get("messages.noPassword"));
+        templateConfig.set("messages.wrongPassword", config.get("messages.wrongPassword"));
+        templateConfig.set("misc.loginCommandGrantedToEveryone", config.get("misc.loginCommandGrantedToEveryone"));
+        templateConfig.set("misc.loginCommandNode", config.get("misc.loginCommandNode"));
+        templateConfig.set("misc.pluginEnabled", config.get("misc.pluginEnabled"));
+
+        //    System.err.println("New Config values:");
+        //    System.err.println("core.loginServer: " + templateConfig.get("core.loginServer"));
+        //      System.err.println("core.hubServer: " + templateConfig.get("core.hubServer"));
+        //      System.err.println("core.serverPassword: " + templateConfig.get("core.serverPassword"));
+        //         System.err.println("core.oneTimeLogin: " + templateConfig.get("core.oneTimeLogin"));
+        //         System.err.println("core.bypass.pluginGrantsBypass: " + templateConfig.get("core.bypass.pluginGrantsBypass"));
+        //         System.err.println("core.bypass.disableLoginCommandOnBypass: " + templateConfig.get("core.bypass.disableLoginCommandOnBypass"));
+        //         System.err.println("core.bypass.bypassNode: " + templateConfig.get("core.bypass.bypassNode"));
+        //         System.err.println("core.bypass.methods.bypassMethod: " + templateConfig.get("core.bypass.methods.bypassMethod"));
+        //         System.err.println("core.bypass.methods.bypassGroup: " + templateConfig.get("core.bypass.methods.bypassGroup"));
+        //         System.err.println("core.kick.kickMessage: " + templateConfig.get("core.kick.kickMessage"));
+        //         System.err.println("core.kick.kickTimeout: " + templateConfig.get("core.kick.kickTimeout"));
+        //         System.err.println("messages.noPassword: " + templateConfig.get("messages.noPassword"));
+        //         System.err.println("messages.wrongPassword: " + templateConfig.get("messages.wrongPassword"));
+        //         System.err.println("misc.loginCommandGrantedToEveryone: " + templateConfig.get("misc.loginCommandGrantedToEveryone"));
+        //         System.err.println("misc.loginCommandNode: " + templateConfig.get("misc.loginCommandNode"));
+        //         System.err.println("misc.configVersion: " + templateConfig.get("misc.configVersion"));
+        //         System.err.println("Build Version: " + BuildConstants.VERSION);
+
+
+
+
+        templateConfig.save();
+        templateConfig.close();
+        config.close();
+        try {
+            Files.copy(templateConfigFile, configFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            Files.delete(templateConfigFile);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+
+
+    }
+    public void migrateYamlToToml() {
+        Path yamlFile = dataDirectory.resolve("config.yml");
+        Path tomlFile = dataDirectory.resolve("config.toml");
+        FileConfig config = FileConfig.of(tomlFile);
+        config.load();
+        final YamlConfigurationLoader loader = YamlConfigurationLoader.builder().path(yamlFile).build();
+        final CommentedConfigurationNode node;
+        try {
+            node = loader.load();
+        } catch (ConfigurateException e) {
+            throw new RuntimeException(e);
+        }
+        config.set("core.loginServer",node.node("loginServer").getString());
+        config.set("core.hubServer",node.node("hubServer").getString());
+        config.set("core.serverPassword",node.node("serverPassword").getString());
+        config.set("core.oneTimeLogin",node.node("oneTimeLogin").getBoolean());
+        config.set("core.bypass.pluginGrantsBypass",node.node("pluginGrantsBypass").getBoolean());
+        config.set("core.bypass.disableLoginCommandOnBypass",node.node("disableLoginCommandOnBypass").getBoolean());
+        config.set("core.bypass.bypassNode",node.node("bypassNode").getString());
+        config.set("core.bypass.methods.bypassMethod",node.node("bypassMethod").getString());
+        config.set("core.bypass.methods.bypassGroup",node.node("bypassGroup").getString());
+        config.set("core.kick.kickMessage",node.node("kickMessage").getString());
+        config.set("core.kick.kickTimeout",node.node("kickTimeout").getLong());
+        config.set("messages.noPassword",node.node("noPassword").getString());
+        config.set("messages.wrongPassword",node.node("wrongPassword").getString());
+        config.set("misc.loginCommandGrantedToEveryone",node.node("loginCommandGrantedToEveryone").getBoolean());
+        config.set("misc.loginCommandNode",node.node("loginCommandNode").getString());
+
+        config.save();
+        config.close();
+        try {
+            Files.delete(yamlFile);
+            logger.info("Old config file deleted.");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+    public void setConfigValue(String key, Object value) {
+        FileConfig config = FileConfig.of(dataDirectory.resolve("config.toml"));
+        config.load();
+        config.set(key, value);
+        config.save();
+        config.close();
+        try {
+            initConfig();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void reloadConfig() {
+        try {
+            initConfig();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    public void togglePlugin() {
+        if(configVar.pluginEnabled) {
+            setConfigValue("misc.pluginEnabled", false);
+        } else {
+            setConfigValue("misc.pluginEnabled", true);
+        }
+
+    }
+
+
+
+
+
+}

--- a/src/main/java/net/trim02/loginPassword/LoginCommand.java
+++ b/src/main/java/net/trim02/loginPassword/LoginCommand.java
@@ -8,7 +8,7 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.trim02.loginPassword.loginPassword.configVar;
+import net.trim02.loginPassword.Config.configVar;
 import org.slf4j.Logger;
 
 import java.util.Optional;

--- a/src/main/java/net/trim02/loginPassword/LoginCommandLuckPerms.java
+++ b/src/main/java/net/trim02/loginPassword/LoginCommandLuckPerms.java
@@ -11,7 +11,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.node.Node;
-import net.trim02.loginPassword.loginPassword.configVar;
+import net.trim02.loginPassword.Config.configVar;
 
 import java.util.Optional;
 

--- a/src/main/java/net/trim02/loginPassword/PlayerConnection.java
+++ b/src/main/java/net/trim02/loginPassword/PlayerConnection.java
@@ -47,7 +47,7 @@ public class PlayerConnection {
         Player player = event.getPlayer();
         RegisteredServer connectedServer = event.getServer();
 
-        if (connectedServer.getServerInfo().getName().equals(configVar.loginServer)) {
+        if (connectedServer.getServerInfo().getName().equals(configVar.loginServer) && configVar.loginCommandNegated.equals(true)) {
             ScheduledTask task = server.getScheduler().buildTask(plugin, () -> player.disconnect(Component.text(configVar.kickMessage))).delay(configVar.kickTimeout, TimeUnit.SECONDS).schedule();
             hashScheduledPlayerTask.put(player.getUniqueId().hashCode(), String.valueOf(task.toString().hashCode()));
 

--- a/src/main/java/net/trim02/loginPassword/PlayerConnection.java
+++ b/src/main/java/net/trim02/loginPassword/PlayerConnection.java
@@ -8,6 +8,7 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.scheduler.ScheduledTask;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.trim02.loginPassword.Config.configVar;
 
 import java.util.Collection;
@@ -38,6 +39,7 @@ public class PlayerConnection {
         } else {
             Optional<RegisteredServer> connectToServer = server.getServer(configVar.loginServer);
             event.setInitialServer(connectToServer.get());
+            player.sendMessage(Component.text(configVar.welcomeMessage, NamedTextColor.GREEN));
         }
     }
 

--- a/src/main/java/net/trim02/loginPassword/PlayerConnection.java
+++ b/src/main/java/net/trim02/loginPassword/PlayerConnection.java
@@ -33,7 +33,7 @@ public class PlayerConnection {
     public void onPlayerJoin(PlayerChooseInitialServerEvent event) {
         Player player = event.getPlayer();
 
-        if (configVar.oneTimeLogin && player.hasPermission(configVar.bypassNode)) {
+        if ((configVar.oneTimeLogin && player.hasPermission(configVar.bypassNode)) || !configVar.pluginEnabled) {
             return;
         } else {
             Optional<RegisteredServer> connectToServer = server.getServer(configVar.loginServer);

--- a/src/main/java/net/trim02/loginPassword/PlayerConnection.java
+++ b/src/main/java/net/trim02/loginPassword/PlayerConnection.java
@@ -8,7 +8,7 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.scheduler.ScheduledTask;
 import net.kyori.adventure.text.Component;
-import net.trim02.loginPassword.loginPassword.configVar;
+import net.trim02.loginPassword.Config.configVar;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/src/main/java/net/trim02/loginPassword/loginPassword.java
+++ b/src/main/java/net/trim02/loginPassword/loginPassword.java
@@ -58,7 +58,7 @@ public class loginPassword {
                             GitHub: %s
                             """.formatted(updateChecker.getCurrentVersion(), updateChecker.getLatestVersion(), updateChecker.getUpdateUrl());
 
-                    logger.warn(updateMessage);
+                    logger.info(updateMessage);
                 }
             } catch (RuntimeException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/net/trim02/loginPassword/loginPassword.java
+++ b/src/main/java/net/trim02/loginPassword/loginPassword.java
@@ -1,6 +1,6 @@
 package net.trim02.loginPassword;
 
-import com.electronwill.nightconfig.core.file.FileConfig;
+
 import com.google.inject.Inject;
 import com.technicjelle.UpdateChecker;
 import com.velocitypowered.api.command.CommandManager;
@@ -14,15 +14,12 @@ import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import org.slf4j.Logger;
-import org.spongepowered.configurate.CommentedConfigurationNode;
-import org.spongepowered.configurate.ConfigurateException;
-import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
+
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
+import net.trim02.loginPassword.Config.configVar;
 
 @Plugin(id = "loginpassword", name = "loginPassword", version = BuildConstants.VERSION, authors = {
         "trim02" }, dependencies = {
@@ -33,319 +30,17 @@ public class loginPassword {
     private final ProxyServer server;
     private final Logger logger;
     private final Path dataDirectory;
+    private final Config config;
 
     @Inject
     public loginPassword(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
         this.server = server;
         this.logger = logger;
         this.dataDirectory = dataDirectory;
+        this.config = new Config(this, server, logger, dataDirectory);
 
     }
 
-    public class configVar {
-        public static String loginServer;
-        public static String hubServer;
-        public static String serverPassword;
-        public static Boolean oneTimeLogin;
-        public static String bypassNode;
-        public static Boolean pluginGrantsBypass;
-        public static String bypassMethod;
-        public static String bypassGroup;
-        public static Boolean disableLoginCommandOnBypass;
-        public static String kickMessage;
-        public static Long kickTimeout;
-        public static String noPassword;
-        public static String wrongPassword;
-        public static Boolean loginCommandNegated;
-        public static String loginCommandNode;
-        public static String configVersion;
-
-    }
-
-    public void initConfigOld() {
-        if (Files.notExists(dataDirectory)) {
-            try {
-                Files.createDirectory(dataDirectory);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        final Path config = dataDirectory.resolve("config.yml");
-        if (Files.notExists(config)) {
-            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.yml")) {
-                Files.copy(stream, config);
-
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        final YamlConfigurationLoader loader = YamlConfigurationLoader.builder().path(config).build();
-        final CommentedConfigurationNode node;
-        try {
-            node = loader.load();
-        } catch (ConfigurateException e) {
-            throw new RuntimeException(e);
-        }
-        configVar.loginServer = node.node("loginServer").getString();
-        configVar.hubServer = node.node("hubServer").getString();
-        configVar.serverPassword = node.node("serverPassword").getString();
-        configVar.oneTimeLogin = node.node("oneTimeLogin").getBoolean();
-        configVar.bypassMethod = node.node("bypassMethod").getString();
-        configVar.bypassGroup = node.node("bypassGroup").getString();
-        configVar.bypassNode = node.node("bypassNode").getString();
-        configVar.pluginGrantsBypass = node.node("pluginGrantsBypass").getBoolean();
-        configVar.disableLoginCommandOnBypass = node.node("disableLoginCommandOnBypass").getBoolean();
-        configVar.kickMessage = node.node("kickMessage").getString();
-        configVar.kickTimeout = node.node("kickTimeout").getLong();
-        configVar.noPassword = node.node("noPassword").getString();
-        configVar.wrongPassword = node.node("wrongPassword").getString();
-        configVar.loginCommandNegated = node.node("loginCommandGrantedToEveryone").getBoolean();
-        configVar.loginCommandNode = node.node("loginCommandNode").getString();
-
-    }
-
-    public void getTomlConfig(Path configFile) {
-        if (Files.notExists(dataDirectory)) {
-            try {
-                Files.createDirectory(dataDirectory);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        // final Path configFile = dataDirectory.resolve("config.toml");
-        if (Files.notExists(configFile)) {
-            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.toml")) {
-                Files.copy(stream, configFile);
-
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        FileConfig config = FileConfig.of(configFile);
-        config.load();
-        configVar.loginServer = config.get("core.loginServer");
-        configVar.hubServer = config.get("core.hubServer");
-        configVar.serverPassword = config.get("core.serverPassword");
-        configVar.oneTimeLogin = config.get("core.oneTimeLogin");
-        configVar.pluginGrantsBypass = config.get("core.bypass.pluginGrantsBypass");
-        configVar.disableLoginCommandOnBypass = config.get("core.bypass.disableLoginCommandOnBypass");
-        configVar.bypassNode = config.get("core.bypass.bypassNode");
-        configVar.bypassMethod = config.get("core.bypass.methods.bypassMethod");
-        configVar.bypassGroup = config.get("core.bypass.methods.bypassGroup");
-        configVar.kickMessage = config.get("core.kick.kickMessage");
-        configVar.kickTimeout = Long.getLong(config.get("core.kick.kickTimeout").toString());
-        configVar.noPassword = config.get("core.messages.noPassword");
-        configVar.wrongPassword = config.get("core.messages.wrongPassword");
-        configVar.loginCommandNegated = config.get("misc.loginCommandGrantedToEveryone");
-        configVar.loginCommandNode = config.get("misc.loginCommandNode");
-        configVar.configVersion = config.get("misc.configVersion");
-        
-
-    }
-
-
-    public void initConfig() throws IOException {
-        if (Files.notExists(dataDirectory)) {
-            try {
-                Files.createDirectory(dataDirectory);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        final Path configFile = dataDirectory.resolve("config.toml");
-        if (Files.notExists(configFile)) {
-            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.toml")) {
-                Files.copy(stream, configFile);
-
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        // Check if the config file is empty
-        if (Files.size(configFile) == 0) {
-            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.toml")) {
-                Files.copy(stream, configFile);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        getTomlConfig(configFile);
-        // Check if local config file version value is different from plugin version
-        if(!configVar.configVersion.equals(BuildConstants.VERSION)){
-            logger.warn("Config file version is different from plugin version. Migrating config file to new version.");
-            migrateConfigVersion();
-        }
-        // Check if old yaml config file exists
-        if (Files.exists(dataDirectory.resolve("config.yml"))) {
-            logger.warn("Old config file found. Migrating to new config file format.");
-            migrateYamlToToml();
-            initConfig();
-        }
-    }
-
-    public void migrateConfigVersion() {
-        Path templateConfigFile = null;
-        try {
-            templateConfigFile = Files.createTempFile(dataDirectory, "configTemp", ".toml");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        InputStream templateStream = this.getClass().getClassLoader().getResourceAsStream("config.toml");
-       try {
-           Files.copy(templateStream, templateConfigFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-       } catch (IOException e) {
-           throw new RuntimeException(e);
-       }
-       Path configFile = dataDirectory.resolve("config.toml");
-
-       FileConfig templateConfig = FileConfig.of(templateConfigFile);
-       FileConfig config = FileConfig.of(configFile);
-       templateConfig.load();
-    //    System.err.println("Template Config values:");
-    //    System.err.println("core.loginServer: " + templateConfig.get("core.loginServer"));
-    //    System.err.println("core.hubServer: " + templateConfig.get("core.hubServer"));
-    //    System.err.println("core.serverPassword: " + templateConfig.get("core.serverPassword"));
-    //    System.err.println("core.oneTimeLogin: " + templateConfig.get("core.oneTimeLogin"));
-    //    System.err.println("core.bypass.pluginGrantsBypass: " + templateConfig.get("core.bypass.pluginGrantsBypass"));
-    //    System.err.println("core.bypass.disableLoginCommandOnBypass: " + templateConfig.get("core.bypass.disableLoginCommandOnBypass"));
-    //    System.err.println("core.bypass.bypassNode: " + templateConfig.get("core.bypass.bypassNode"));
-    //    System.err.println("core.bypass.methods.bypassMethod: " + templateConfig.get("core.bypass.methods.bypassMethod"));
-    //    System.err.println("core.bypass.methods.bypassGroup: " + templateConfig.get("core.bypass.methods.bypassGroup"));
-    //    System.err.println("core.kick.kickMessage: " + templateConfig.get("core.kick.kickMessage"));
-    //    System.err.println("core.kick.kickTimeout: " + templateConfig.get("core.kick.kickTimeout"));
-    //    System.err.println("messages.noPassword: " + templateConfig.get("messages.noPassword"));
-    //    System.err.println("messages.wrongPassword: " + templateConfig.get("messages.wrongPassword"));
-    //    System.err.println("misc.loginCommandGrantedToEveryone: " + templateConfig.get("misc.loginCommandGrantedToEveryone"));
-    //    System.err.println("misc.loginCommandNode: " + templateConfig.get("misc.loginCommandNode"));
-    //    System.err.println("misc.configVersion: " + templateConfig.get("misc.configVersion"));
-    //    System.err.println("Build Version: " + BuildConstants.VERSION);
-       config.load();
-    //    System.err.println("Local Config values:");
-    //    System.err.println("core.loginServer: " + config.get("core.loginServer"));
-    //    System.err.println("core.hubServer: " + config.get("core.hubServer"));
-    //    System.err.println("core.serverPassword: " + config.get("core.serverPassword"));
-    //    System.err.println("core.oneTimeLogin: " + config.get("core.oneTimeLogin"));
-    //    System.err.println("core.bypass.pluginGrantsBypass: " + config.get("core.bypass.pluginGrantsBypass"));
-    //    System.err.println("core.bypass.disableLoginCommandOnBypass: " + config.get("core.bypass.disableLoginCommandOnBypass"));
-    //    System.err.println("core.bypass.bypassNode: " + config.get("core.bypass.bypassNode"));
-    //    System.err.println("core.bypass.methods.bypassMethod: " + config.get("core.bypass.methods.bypassMethod"));
-    //    System.err.println("core.bypass.methods.bypassGroup: " + config.get("core.bypass.methods.bypassGroup"));
-    //    System.err.println("core.kick.kickMessage: " + config.get("core.kick.kickMessage"));
-    //    System.err.println("core.kick.kickTimeout: " + config.get("core.kick.kickTimeout"));
-    //    System.err.println("messages.noPassword: " + config.get("messages.noPassword"));
-    //    System.err.println("messages.wrongPassword: " + config.get("messages.wrongPassword"));
-    //    System.err.println("misc.loginCommandGrantedToEveryone: " + config.get("misc.loginCommandGrantedToEveryone"));
-    //    System.err.println("misc.loginCommandNode: " + config.get("misc.loginCommandNode"));
-    //    System.err.println("misc.configVersion: " + config.get("misc.configVersion"));
-    //    System.err.println("Build Version: " + BuildConstants.VERSION);
-       templateConfig.set("core.loginServer", config.get("core.loginServer"));
-       templateConfig.set("core.hubServer", config.get("core.hubServer"));
-       templateConfig.set("core.serverPassword", config.get("core.serverPassword"));
-       templateConfig.set("core.oneTimeLogin", config.get("core.oneTimeLogin"));
-       templateConfig.set("core.bypass.pluginGrantsBypass", config.get("core.bypass.pluginGrantsBypass"));
-       templateConfig.set("core.bypass.disableLoginCommandOnBypass", config.get("core.bypass.disableLoginCommandOnBypass"));
-       templateConfig.set("core.bypass.bypassNode", config.get("core.bypass.bypassNode"));
-       templateConfig.set("core.bypass.methods.bypassMethod", config.get("core.bypass.methods.bypassMethod"));
-       templateConfig.set("core.bypass.methods.bypassGroup", config.get("core.bypass.methods.bypassGroup"));
-       templateConfig.set("core.kick.kickMessage", config.get("core.kick.kickMessage"));
-       templateConfig.set("core.kick.kickTimeout", config.get("core.kick.kickTimeout"));
-       templateConfig.set("messages.noPassword", config.get("messages.noPassword"));
-       templateConfig.set("messages.wrongPassword", config.get("messages.wrongPassword"));
-       templateConfig.set("misc.loginCommandGrantedToEveryone", config.get("misc.loginCommandGrantedToEveryone"));
-       templateConfig.set("misc.loginCommandNode", config.get("misc.loginCommandNode"));
-
-    //    System.err.println("New Config values:");
-    //    System.err.println("core.loginServer: " + templateConfig.get("core.loginServer"));
-    //      System.err.println("core.hubServer: " + templateConfig.get("core.hubServer"));
-    //      System.err.println("core.serverPassword: " + templateConfig.get("core.serverPassword"));
-    //         System.err.println("core.oneTimeLogin: " + templateConfig.get("core.oneTimeLogin"));
-    //         System.err.println("core.bypass.pluginGrantsBypass: " + templateConfig.get("core.bypass.pluginGrantsBypass"));
-    //         System.err.println("core.bypass.disableLoginCommandOnBypass: " + templateConfig.get("core.bypass.disableLoginCommandOnBypass"));
-    //         System.err.println("core.bypass.bypassNode: " + templateConfig.get("core.bypass.bypassNode"));
-    //         System.err.println("core.bypass.methods.bypassMethod: " + templateConfig.get("core.bypass.methods.bypassMethod"));
-    //         System.err.println("core.bypass.methods.bypassGroup: " + templateConfig.get("core.bypass.methods.bypassGroup"));
-    //         System.err.println("core.kick.kickMessage: " + templateConfig.get("core.kick.kickMessage"));
-    //         System.err.println("core.kick.kickTimeout: " + templateConfig.get("core.kick.kickTimeout"));
-    //         System.err.println("messages.noPassword: " + templateConfig.get("messages.noPassword"));
-    //         System.err.println("messages.wrongPassword: " + templateConfig.get("messages.wrongPassword"));
-    //         System.err.println("misc.loginCommandGrantedToEveryone: " + templateConfig.get("misc.loginCommandGrantedToEveryone"));
-    //         System.err.println("misc.loginCommandNode: " + templateConfig.get("misc.loginCommandNode"));
-    //         System.err.println("misc.configVersion: " + templateConfig.get("misc.configVersion"));
-    //         System.err.println("Build Version: " + BuildConstants.VERSION);
-
-
-
-
-       templateConfig.save();
-       templateConfig.close();
-       try {
-            Files.copy(templateConfigFile, configFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-            Files.delete(templateConfigFile);
-       }
-         catch (IOException e) {
-                throw new RuntimeException(e);
-         }
-
-
-
-    }
-    public void migrateYamlToToml() {
-        Path yamlFile = dataDirectory.resolve("config.yml");
-        Path tomlFile = dataDirectory.resolve("config.toml");
-        FileConfig config = FileConfig.of(tomlFile);
-        config.load();
-        final YamlConfigurationLoader loader = YamlConfigurationLoader.builder().path(yamlFile).build();
-        final CommentedConfigurationNode node;
-        try {
-            node = loader.load();
-        } catch (ConfigurateException e) {
-            throw new RuntimeException(e);
-        }
-        config.set("core.loginServer",node.node("loginServer").getString());
-        config.set("core.hubServer",node.node("hubServer").getString());
-        config.set("core.serverPassword",node.node("serverPassword").getString());
-        config.set("core.oneTimeLogin",node.node("oneTimeLogin").getBoolean());
-        config.set("core.bypass.pluginGrantsBypass",node.node("pluginGrantsBypass").getBoolean());
-        config.set("core.bypass.disableLoginCommandOnBypass",node.node("disableLoginCommandOnBypass").getBoolean());
-        config.set("core.bypass.bypassNode",node.node("bypassNode").getString());
-        config.set("core.bypass.methods.bypassMethod",node.node("bypassMethod").getString());
-        config.set("core.bypass.methods.bypassGroup",node.node("bypassGroup").getString());
-        config.set("core.kick.kickMessage",node.node("kickMessage").getString());
-        config.set("core.kick.kickTimeout",node.node("kickTimeout").getLong());
-        config.set("messages.noPassword",node.node("noPassword").getString());
-        config.set("messages.wrongPassword",node.node("wrongPassword").getString());
-        config.set("misc.loginCommandGrantedToEveryone",node.node("loginCommandGrantedToEveryone").getBoolean());
-        config.set("misc.loginCommandNode",node.node("loginCommandNode").getString());
-        
-        config.save();
-        config.close();
-        try {
-            Files.delete(yamlFile);
-            logger.info("Old config file deleted.");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        
-    }
-
-
-
-
-
-
-
-
-
-    public Boolean setConfigValue(String key, Object value) {
-        FileConfig config = FileConfig.of(dataDirectory.resolve("config.toml"));
-        config.load();
-        config.set(key, value);
-        config.save();
-        config.close();
-        return true;
-    }
-    
 
     @Subscribe
     public void onProxyInitialization(ProxyInitializeEvent event) {
@@ -372,7 +67,7 @@ public class loginPassword {
 
         
         try {
-            initConfig();
+            config.initConfig();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -402,7 +97,7 @@ public class loginPassword {
     @Subscribe
     public void onProxyReload(ProxyReloadEvent event) {
         try {
-            initConfig();
+           config.initConfig();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/net/trim02/loginPassword/loginPassword.java
+++ b/src/main/java/net/trim02/loginPassword/loginPassword.java
@@ -1,6 +1,7 @@
 package net.trim02.loginPassword;
 
 import com.google.inject.Inject;
+import com.technicjelle.UpdateChecker;
 import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.command.CommandMeta;
 import com.velocitypowered.api.command.SimpleCommand;
@@ -15,11 +16,11 @@ import org.slf4j.Logger;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.spongepowered.configurate.ConfigurateException;
 import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 @Plugin(id = "loginpassword", name = "loginPassword", version = BuildConstants.VERSION, authors = {
         "trim02" }, dependencies = {
@@ -102,6 +103,27 @@ public class loginPassword {
 
     @Subscribe
     public void onProxyInitialization(ProxyInitializeEvent event) {
+        
+        UpdateChecker updateChecker = new UpdateChecker("trim02", "loginPassword", BuildConstants.VERSION);
+        server.getScheduler().buildTask(this, () -> {
+            try {
+                updateChecker.check();
+                if (updateChecker.isUpdateAvailable()) {
+
+                    var updateMessage = """
+                            A new version is available: %s -> %s. Download the new version here:
+                            modrinth: https://modrinth.com/plugin/loginpassword
+                            Hangar: https://hangar.papermc.io/trim02/loginPassword
+                            GitHub: %s
+                            """.formatted(updateChecker.getCurrentVersion(), updateChecker.getLatestVersion(), updateChecker.getUpdateUrl());
+
+                    logger.warn(updateMessage);
+                }
+            } catch (RuntimeException e) {
+                throw new RuntimeException(e);
+            }
+        }).repeat(7, TimeUnit.DAYS).schedule();
+
         
         initConfig();
         

--- a/src/main/java/net/trim02/loginPassword/loginPassword.java
+++ b/src/main/java/net/trim02/loginPassword/loginPassword.java
@@ -1,5 +1,6 @@
 package net.trim02.loginPassword;
 
+import com.electronwill.nightconfig.core.file.FileConfig;
 import com.google.inject.Inject;
 import com.technicjelle.UpdateChecker;
 import com.velocitypowered.api.command.CommandManager;
@@ -21,6 +22,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
+
 
 @Plugin(id = "loginpassword", name = "loginPassword", version = BuildConstants.VERSION, authors = {
         "trim02" }, dependencies = {
@@ -56,10 +58,11 @@ public class loginPassword {
         public static String wrongPassword;
         public static Boolean loginCommandNegated;
         public static String loginCommandNode;
+        public static String configVersion;
 
     }
 
-    public void initConfig() {
+    public void initConfigOld() {
         if (Files.notExists(dataDirectory)) {
             try {
                 Files.createDirectory(dataDirectory);
@@ -101,6 +104,249 @@ public class loginPassword {
 
     }
 
+    public void getTomlConfig(Path configFile) {
+        if (Files.notExists(dataDirectory)) {
+            try {
+                Files.createDirectory(dataDirectory);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        // final Path configFile = dataDirectory.resolve("config.toml");
+        if (Files.notExists(configFile)) {
+            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.toml")) {
+                Files.copy(stream, configFile);
+
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        FileConfig config = FileConfig.of(configFile);
+        config.load();
+        configVar.loginServer = config.get("core.loginServer");
+        configVar.hubServer = config.get("core.hubServer");
+        configVar.serverPassword = config.get("core.serverPassword");
+        configVar.oneTimeLogin = config.get("core.oneTimeLogin");
+        configVar.pluginGrantsBypass = config.get("core.bypass.pluginGrantsBypass");
+        configVar.disableLoginCommandOnBypass = config.get("core.bypass.disableLoginCommandOnBypass");
+        configVar.bypassNode = config.get("core.bypass.bypassNode");
+        configVar.bypassMethod = config.get("core.bypass.methods.bypassMethod");
+        configVar.bypassGroup = config.get("core.bypass.methods.bypassGroup");
+        configVar.kickMessage = config.get("core.kick.kickMessage");
+        configVar.kickTimeout = Long.getLong(config.get("core.kick.kickTimeout").toString());
+        configVar.noPassword = config.get("core.messages.noPassword");
+        configVar.wrongPassword = config.get("core.messages.wrongPassword");
+        configVar.loginCommandNegated = config.get("misc.loginCommandGrantedToEveryone");
+        configVar.loginCommandNode = config.get("misc.loginCommandNode");
+        configVar.configVersion = config.get("misc.configVersion");
+        
+
+    }
+
+
+    public void initConfig() throws IOException {
+        if (Files.notExists(dataDirectory)) {
+            try {
+                Files.createDirectory(dataDirectory);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        final Path configFile = dataDirectory.resolve("config.toml");
+        if (Files.notExists(configFile)) {
+            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.toml")) {
+                Files.copy(stream, configFile);
+
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        // Check if the config file is empty
+        if (Files.size(configFile) == 0) {
+            try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream("config.toml")) {
+                Files.copy(stream, configFile);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        getTomlConfig(configFile);
+        // Check if local config file version value is different from plugin version
+        if(!configVar.configVersion.equals(BuildConstants.VERSION)){
+            logger.warn("Config file version is different from plugin version. Migrating config file to new version.");
+            migrateConfigVersion();
+        }
+        // Check if old yaml config file exists
+        if (Files.exists(dataDirectory.resolve("config.yml"))) {
+            logger.warn("Old config file found. Migrating to new config file format.");
+            migrateYamlToToml();
+            initConfig();
+        }
+    }
+
+    public void migrateConfigVersion() {
+        Path templateConfigFile = null;
+        try {
+            templateConfigFile = Files.createTempFile(dataDirectory, "configTemp", ".toml");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        InputStream templateStream = this.getClass().getClassLoader().getResourceAsStream("config.toml");
+       try {
+           Files.copy(templateStream, templateConfigFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+       } catch (IOException e) {
+           throw new RuntimeException(e);
+       }
+       Path configFile = dataDirectory.resolve("config.toml");
+
+       FileConfig templateConfig = FileConfig.of(templateConfigFile);
+       FileConfig config = FileConfig.of(configFile);
+       templateConfig.load();
+    //    System.err.println("Template Config values:");
+    //    System.err.println("core.loginServer: " + templateConfig.get("core.loginServer"));
+    //    System.err.println("core.hubServer: " + templateConfig.get("core.hubServer"));
+    //    System.err.println("core.serverPassword: " + templateConfig.get("core.serverPassword"));
+    //    System.err.println("core.oneTimeLogin: " + templateConfig.get("core.oneTimeLogin"));
+    //    System.err.println("core.bypass.pluginGrantsBypass: " + templateConfig.get("core.bypass.pluginGrantsBypass"));
+    //    System.err.println("core.bypass.disableLoginCommandOnBypass: " + templateConfig.get("core.bypass.disableLoginCommandOnBypass"));
+    //    System.err.println("core.bypass.bypassNode: " + templateConfig.get("core.bypass.bypassNode"));
+    //    System.err.println("core.bypass.methods.bypassMethod: " + templateConfig.get("core.bypass.methods.bypassMethod"));
+    //    System.err.println("core.bypass.methods.bypassGroup: " + templateConfig.get("core.bypass.methods.bypassGroup"));
+    //    System.err.println("core.kick.kickMessage: " + templateConfig.get("core.kick.kickMessage"));
+    //    System.err.println("core.kick.kickTimeout: " + templateConfig.get("core.kick.kickTimeout"));
+    //    System.err.println("messages.noPassword: " + templateConfig.get("messages.noPassword"));
+    //    System.err.println("messages.wrongPassword: " + templateConfig.get("messages.wrongPassword"));
+    //    System.err.println("misc.loginCommandGrantedToEveryone: " + templateConfig.get("misc.loginCommandGrantedToEveryone"));
+    //    System.err.println("misc.loginCommandNode: " + templateConfig.get("misc.loginCommandNode"));
+    //    System.err.println("misc.configVersion: " + templateConfig.get("misc.configVersion"));
+    //    System.err.println("Build Version: " + BuildConstants.VERSION);
+       config.load();
+    //    System.err.println("Local Config values:");
+    //    System.err.println("core.loginServer: " + config.get("core.loginServer"));
+    //    System.err.println("core.hubServer: " + config.get("core.hubServer"));
+    //    System.err.println("core.serverPassword: " + config.get("core.serverPassword"));
+    //    System.err.println("core.oneTimeLogin: " + config.get("core.oneTimeLogin"));
+    //    System.err.println("core.bypass.pluginGrantsBypass: " + config.get("core.bypass.pluginGrantsBypass"));
+    //    System.err.println("core.bypass.disableLoginCommandOnBypass: " + config.get("core.bypass.disableLoginCommandOnBypass"));
+    //    System.err.println("core.bypass.bypassNode: " + config.get("core.bypass.bypassNode"));
+    //    System.err.println("core.bypass.methods.bypassMethod: " + config.get("core.bypass.methods.bypassMethod"));
+    //    System.err.println("core.bypass.methods.bypassGroup: " + config.get("core.bypass.methods.bypassGroup"));
+    //    System.err.println("core.kick.kickMessage: " + config.get("core.kick.kickMessage"));
+    //    System.err.println("core.kick.kickTimeout: " + config.get("core.kick.kickTimeout"));
+    //    System.err.println("messages.noPassword: " + config.get("messages.noPassword"));
+    //    System.err.println("messages.wrongPassword: " + config.get("messages.wrongPassword"));
+    //    System.err.println("misc.loginCommandGrantedToEveryone: " + config.get("misc.loginCommandGrantedToEveryone"));
+    //    System.err.println("misc.loginCommandNode: " + config.get("misc.loginCommandNode"));
+    //    System.err.println("misc.configVersion: " + config.get("misc.configVersion"));
+    //    System.err.println("Build Version: " + BuildConstants.VERSION);
+       templateConfig.set("core.loginServer", config.get("core.loginServer"));
+       templateConfig.set("core.hubServer", config.get("core.hubServer"));
+       templateConfig.set("core.serverPassword", config.get("core.serverPassword"));
+       templateConfig.set("core.oneTimeLogin", config.get("core.oneTimeLogin"));
+       templateConfig.set("core.bypass.pluginGrantsBypass", config.get("core.bypass.pluginGrantsBypass"));
+       templateConfig.set("core.bypass.disableLoginCommandOnBypass", config.get("core.bypass.disableLoginCommandOnBypass"));
+       templateConfig.set("core.bypass.bypassNode", config.get("core.bypass.bypassNode"));
+       templateConfig.set("core.bypass.methods.bypassMethod", config.get("core.bypass.methods.bypassMethod"));
+       templateConfig.set("core.bypass.methods.bypassGroup", config.get("core.bypass.methods.bypassGroup"));
+       templateConfig.set("core.kick.kickMessage", config.get("core.kick.kickMessage"));
+       templateConfig.set("core.kick.kickTimeout", config.get("core.kick.kickTimeout"));
+       templateConfig.set("messages.noPassword", config.get("messages.noPassword"));
+       templateConfig.set("messages.wrongPassword", config.get("messages.wrongPassword"));
+       templateConfig.set("misc.loginCommandGrantedToEveryone", config.get("misc.loginCommandGrantedToEveryone"));
+       templateConfig.set("misc.loginCommandNode", config.get("misc.loginCommandNode"));
+
+    //    System.err.println("New Config values:");
+    //    System.err.println("core.loginServer: " + templateConfig.get("core.loginServer"));
+    //      System.err.println("core.hubServer: " + templateConfig.get("core.hubServer"));
+    //      System.err.println("core.serverPassword: " + templateConfig.get("core.serverPassword"));
+    //         System.err.println("core.oneTimeLogin: " + templateConfig.get("core.oneTimeLogin"));
+    //         System.err.println("core.bypass.pluginGrantsBypass: " + templateConfig.get("core.bypass.pluginGrantsBypass"));
+    //         System.err.println("core.bypass.disableLoginCommandOnBypass: " + templateConfig.get("core.bypass.disableLoginCommandOnBypass"));
+    //         System.err.println("core.bypass.bypassNode: " + templateConfig.get("core.bypass.bypassNode"));
+    //         System.err.println("core.bypass.methods.bypassMethod: " + templateConfig.get("core.bypass.methods.bypassMethod"));
+    //         System.err.println("core.bypass.methods.bypassGroup: " + templateConfig.get("core.bypass.methods.bypassGroup"));
+    //         System.err.println("core.kick.kickMessage: " + templateConfig.get("core.kick.kickMessage"));
+    //         System.err.println("core.kick.kickTimeout: " + templateConfig.get("core.kick.kickTimeout"));
+    //         System.err.println("messages.noPassword: " + templateConfig.get("messages.noPassword"));
+    //         System.err.println("messages.wrongPassword: " + templateConfig.get("messages.wrongPassword"));
+    //         System.err.println("misc.loginCommandGrantedToEveryone: " + templateConfig.get("misc.loginCommandGrantedToEveryone"));
+    //         System.err.println("misc.loginCommandNode: " + templateConfig.get("misc.loginCommandNode"));
+    //         System.err.println("misc.configVersion: " + templateConfig.get("misc.configVersion"));
+    //         System.err.println("Build Version: " + BuildConstants.VERSION);
+
+
+
+
+       templateConfig.save();
+       templateConfig.close();
+       try {
+            Files.copy(templateConfigFile, configFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            Files.delete(templateConfigFile);
+       }
+         catch (IOException e) {
+                throw new RuntimeException(e);
+         }
+
+
+
+    }
+    public void migrateYamlToToml() {
+        Path yamlFile = dataDirectory.resolve("config.yml");
+        Path tomlFile = dataDirectory.resolve("config.toml");
+        FileConfig config = FileConfig.of(tomlFile);
+        config.load();
+        final YamlConfigurationLoader loader = YamlConfigurationLoader.builder().path(yamlFile).build();
+        final CommentedConfigurationNode node;
+        try {
+            node = loader.load();
+        } catch (ConfigurateException e) {
+            throw new RuntimeException(e);
+        }
+        config.set("core.loginServer",node.node("loginServer").getString());
+        config.set("core.hubServer",node.node("hubServer").getString());
+        config.set("core.serverPassword",node.node("serverPassword").getString());
+        config.set("core.oneTimeLogin",node.node("oneTimeLogin").getBoolean());
+        config.set("core.bypass.pluginGrantsBypass",node.node("pluginGrantsBypass").getBoolean());
+        config.set("core.bypass.disableLoginCommandOnBypass",node.node("disableLoginCommandOnBypass").getBoolean());
+        config.set("core.bypass.bypassNode",node.node("bypassNode").getString());
+        config.set("core.bypass.methods.bypassMethod",node.node("bypassMethod").getString());
+        config.set("core.bypass.methods.bypassGroup",node.node("bypassGroup").getString());
+        config.set("core.kick.kickMessage",node.node("kickMessage").getString());
+        config.set("core.kick.kickTimeout",node.node("kickTimeout").getLong());
+        config.set("messages.noPassword",node.node("noPassword").getString());
+        config.set("messages.wrongPassword",node.node("wrongPassword").getString());
+        config.set("misc.loginCommandGrantedToEveryone",node.node("loginCommandGrantedToEveryone").getBoolean());
+        config.set("misc.loginCommandNode",node.node("loginCommandNode").getString());
+        
+        config.save();
+        config.close();
+        try {
+            Files.delete(yamlFile);
+            logger.info("Old config file deleted.");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        
+    }
+
+
+
+
+
+
+
+
+
+    public Boolean setConfigValue(String key, Object value) {
+        FileConfig config = FileConfig.of(dataDirectory.resolve("config.toml"));
+        config.load();
+        config.set(key, value);
+        config.save();
+        config.close();
+        return true;
+    }
+    
+
     @Subscribe
     public void onProxyInitialization(ProxyInitializeEvent event) {
         
@@ -125,8 +371,15 @@ public class loginPassword {
         }).repeat(7, TimeUnit.DAYS).schedule();
 
         
-        initConfig();
+        try {
+            initConfig();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         
+
+
+
         server.getEventManager().register(this, new PlayerConnection(server, this));
         CommandManager commandManager = server.getCommandManager();
         CommandMeta commandMeta = commandManager.metaBuilder("login").plugin(this).build();
@@ -148,7 +401,11 @@ public class loginPassword {
 
     @Subscribe
     public void onProxyReload(ProxyReloadEvent event) {
-        initConfig();
+        try {
+            initConfig();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         logger.info("Config reloaded!");
     }
 }

--- a/src/main/java/net/trim02/loginPassword/loginPassword.java
+++ b/src/main/java/net/trim02/loginPassword/loginPassword.java
@@ -77,20 +77,23 @@ public class loginPassword {
 
         server.getEventManager().register(this, new PlayerConnection(server, this));
         CommandManager commandManager = server.getCommandManager();
-        CommandMeta commandMeta = commandManager.metaBuilder("login").plugin(this).build();
+        CommandMeta commandMetaLogin = commandManager.metaBuilder("login").plugin(this).build();
+        CommandMeta commandMetaAdmin = commandManager.metaBuilder("loginpassword").plugin(this).build();
 
         if (server.getPluginManager().isLoaded("luckperms")) {
             logger.debug("luckperms found!");
             SimpleCommand loginCommand = new LoginCommandLuckPerms(server, logger);
-            commandManager.register(commandMeta, loginCommand);
+            commandManager.register(commandMetaLogin, loginCommand);
         } else {
             if(configVar.pluginGrantsBypass.equals(true) && configVar.oneTimeLogin.equals(true)){
                 logger.warn("pluginGrantsBypass is set to true but LuckPerms is not found. Please disable pluginGrantsBypass in the config file, as this setting will not work without LuckPerms. Bypass permissions must be granted manually.");
             }
             SimpleCommand loginCommand = new LoginCommand(server, logger);
-            commandManager.register(commandMeta, loginCommand);
+            commandManager.register(commandMetaLogin, loginCommand);
 
         }
+        SimpleCommand adminCommand = new AdminCommand(server, logger, config);
+        commandManager.register(commandMetaAdmin, adminCommand);
         logger.info("Plugin ready!");
     }
 

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -1,0 +1,41 @@
+[core]
+	# The server name set in Velocity that is used for logging in
+	loginServer = "login"
+	# The server name set in Velocity that the player will be transferred to after logging in
+	hubServer = "hub"
+	# The password players must input to log in
+	serverPassword = "1234"
+	# Change to false to make players have to write the password on every connection.
+	oneTimeLogin = true
+    # Bypass settings require oneTimeLogin to be true
+[core.bypass]
+	# if set to true, the plugin will grant bypass permission to players. Requires LuckPerms. If you don't use LuckPerms, you must set the bypass permissions manually
+	pluginGrantsBypass = true
+    # Set to false to allow the login command to be used by players with bypass permission
+	disableLoginCommandOnBypass = true  
+
+	# Remember to disallow the velocity.command.server permission for all players to prevent them from joining the server without logging in first
+	# the permission node to check if a player has bypass permissions. Must exist either on the user or on a group the user is in
+	bypassNode = "loginpassword.bypass"
+    [core.bypass.methods]
+    # method to grant bypass permissions. "user" will grant the bypassNode to the player, "group" will add the player to the bypassGroup. the group must exist in the permissions plugin, and multiple groups can exist with the permission node
+	bypassMethod = "user"
+	bypassGroup = "default"
+  
+[core.kick]
+	# The amount of time to wait before kicking the player. In seconds
+	kickTimeout = 30
+	# Message to be sent to player if they fail to provide password after kickTimeout.
+	kickMessage = "You were kicked for failing to provide the password after 30 seconds"
+[messages]
+	# Messages to be sent to player when they do not provide or gives a wrong password
+    wrongPassword = "Wrong Password."
+	noPassword = "Please provide a password. It can be found on Discord"
+
+
+[misc]
+	configVersion = "1.4-SNAPSHOT"
+	# set to false to make the login command only accessible to players with the permission node loginpassword.login.
+	# this could be used to have a private server where only some players have access to. oneTimeLogin must be disabled otherwise players with the bypass permissions will always be sent to the private server.
+	loginCommandGrantedToEveryone = true
+	loginCommandNode = "loginpassword.login"

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -31,6 +31,7 @@
 	# Messages to be sent to player when they do not provide or gives a wrong password
     wrongPassword = "Wrong Password."
 	noPassword = "Please provide a password. It can be found on Discord"
+	welcomeMessage = "Please type /login <password> to log in."
 
 
 [misc]

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -35,6 +35,7 @@
 
 [misc]
 	configVersion = "1.4-SNAPSHOT"
+	pluginEnabled = true
 	# set to false to make the login command only accessible to players with the permission node loginpassword.login.
 	# this could be used to have a private server where only some players have access to. oneTimeLogin must be disabled otherwise players with the bypass permissions will always be sent to the private server.
 	loginCommandGrantedToEveryone = true

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -18,7 +18,7 @@
 	# the permission node to check if a player has bypass permissions. Must exist either on the user or on a group the user is in
 	bypassNode = "loginpassword.bypass"
     [core.bypass.methods]
-    # method to grant bypass permissions. "user" will grant the bypassNode to the player, "group" will add the player to the bypassGroup. the group must exist in the permissions plugin, and multiple groups can exist with the permission node
+    # method to grant bypass permissions. "user" will grant the bypassNode to the player, "group" will add the player to the bypassGroup. the group must exist in the permissions plugin, and multiple groups can exist with the permission node.
 	bypassMethod = "user"
 	bypassGroup = "default"
   

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -35,7 +35,7 @@
 
 
 [misc]
-	configVersion = "1.4-SNAPSHOT"
+	configVersion = "1.4"
 	pluginEnabled = true
 	# set to false to make the login command only accessible to players with the permission node loginpassword.login.
 	# this could be used to have a private server where only some players have access to. oneTimeLogin must be disabled otherwise players with the bypass permissions will always be sent to the private server.


### PR DESCRIPTION
Major changes:

- Changed config file format from YAML to TOML. Plugin will migrate automatically.
- Added an update checker to check for new versions of the plugin.
- Moved config stuff into its own file.
- Added commands to see the config, reload the config, or toggle the plugin on or off, from the console or as a player with the command `/loginpassword`, the permission node is `loginpassword.admin`. 
- Added config key to enable or disable the plugins functionality. Use the commands to do it in-game/from the console
- Added a welcome message for when players join the login server, with the config key `welcomeMessage`. Improvement #2 
- In the config comments there is a situation presented where you could use this plugin to restrict access to a another server with a password, however the config key did not work properly. It does now.
